### PR TITLE
fix `freigaben` translation

### DIFF
--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Windows.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Windows.md
@@ -2,7 +2,7 @@
 
 ## <a name="msi"></a>MSI
 
-Installieren Sie PowerShell auf einem Windows-Client oder Windows Server-Computer (funktioniert unter Windows 7 SP1, Windows Server 2008 R2 und höher), indem Sie das MSI-Paket von unserer GitHub-Seite mit [Freigaben][] herunterladen.
+Installieren Sie PowerShell auf einem Windows-Client oder Windows Server-Computer (funktioniert unter Windows 7 SP1, Windows Server 2008 R2 und höher), indem Sie das MSI-Paket von unserer GitHub-[releases][]-Seite herunterladen.
 
 Die MSI-Datei sieht wie folgt aus: `PowerShell-<version>-win-<os-arch>.msi`
 <!-- TODO: should be updated to point to the Download Center as well -->

--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Windows.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Windows.md
@@ -2,7 +2,7 @@
 
 ## <a name="msi"></a>MSI
 
-Installieren Sie PowerShell auf einem Windows-Client oder Windows Server-Computer (funktioniert unter Windows 7 SP1, Windows Server 2008 R2 und höher), indem Sie das MSI-Paket von unserer GitHub-[releases][]-Seite herunterladen.
+Installieren Sie PowerShell auf einem Windows-Client oder Windows Server-Computer (funktioniert unter Windows 7 SP1, Windows Server 2008 R2 und höher), indem Sie das MSI-Paket von unserer GitHub-[Releases][]-Seite herunterladen.
 
 Die MSI-Datei sieht wie folgt aus: `PowerShell-<version>-win-<os-arch>.msi`
 <!-- TODO: should be updated to point to the Download Center as well -->


### PR DESCRIPTION
the english page uses [releases][] which generates a link to the release page. If releases is translated github no longer shows the correct link.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell-docs.de-de/6)
<!-- Reviewable:end -->
